### PR TITLE
Fix a bug with date range with add action

### DIFF
--- a/tests/test_timereport.py
+++ b/tests/test_timereport.py
@@ -7,7 +7,17 @@ from timereport.chalicelib.lib.add import post_event
 from mockito import when, mock, unstub
 import botocore.vendored.requests.api as requests
 
+
+import logging
+import sys
+
+logging.basicConfig(
+    # Change to logging.DEBUG to get debugging messages to stdout
+    stream=sys.stdout, level=logging.DEBUG, format="%(message)s"
+)
+
 dir_path = os.path.dirname(os.path.realpath(__file__))
+
 
 def test_parsing_config():
     test_config = parse_config(f'{dir_path}/config.yaml')
@@ -26,10 +36,15 @@ def test_slack_payload_extractor_message():
 
 @pytest.mark.parametrize(
     "date_string",
-    ["2018-01-01", "today", "today 8", "today 24"]
+    ["2018-01-01", "today", "today 8", "today 24", "2019-01-01:2019-02-01"]
 )
 def test_factory(date_string):
-    fake_order = dict(user_id='fake', user_name='fake mcFake', text=[f'fake_cmd=do_fake fake_reason {date_string}'])
+    fake_order = dict(
+        user_id='fake',
+        user_name='fake mcFake',
+        text=[f'fake_cmd=do_fake fake_reason {date_string}']
+    )
+
     fake_result = factory(fake_order)
     assert isinstance(fake_result, list)
     test_data = fake_result.pop()

--- a/tests/test_timereport.py
+++ b/tests/test_timereport.py
@@ -8,14 +8,6 @@ from mockito import when, mock, unstub
 import botocore.vendored.requests.api as requests
 
 
-import logging
-import sys
-
-logging.basicConfig(
-    # Change to logging.DEBUG to get debugging messages to stdout
-    stream=sys.stdout, level=logging.DEBUG, format="%(message)s"
-)
-
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 

--- a/timereport/chalicelib/lib/factory.py
+++ b/timereport/chalicelib/lib/factory.py
@@ -39,14 +39,14 @@ def factory(order):
         date_obj_stop = datetime.strptime(date_str_stop, format_str)
         for d in date_range(date_obj_start, date_obj_stop):
             dates.append(d)
-
-    if "today" in date_str:
+    elif "today" in date_str:
         date_obj = datetime.now().date()
         dates.append(date_obj)
     else:
         log.debug(f"Will try to convert string {date_str} to a datetime object")
         date_obj = datetime.strptime(date_str, format_str)
         dates.append(date_obj)
+
     for event_date in dates:
         e = create_event(user_id, user_name, reason, event_date, hours)
         events.append(e)

--- a/timereport/chalicelib/lib/factory.py
+++ b/timereport/chalicelib/lib/factory.py
@@ -21,6 +21,7 @@ def factory(order):
         return False
 
     reason, date_str = cmd[1:3]
+    log.debug(f"Date string is: {date_str}")
 
     try:
         hours = round(float(cmd[3]), 1)
@@ -43,6 +44,7 @@ def factory(order):
         date_obj = datetime.now().date()
         dates.append(date_obj)
     else:
+        log.debug(f"Will try to convert string {date_str} to a datetime object")
         date_obj = datetime.strptime(date_str, format_str)
         dates.append(date_obj)
     for event_date in dates:


### PR DESCRIPTION
When I added `"2019-01-01:2019-02-01"` as the input to the `test_factory` function it fails with this message:
`ValueError: unconverted data remains: :2019-02-01`

It seems that it tries to convert the string that contains `"2019-01-01:2019-02-01"` instead of the individual date strings

Log messages added shows this:
```
-------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------
Date string is: 2019-01-01:2019-02-01
Will try to convert string 2019-01-01:2019-02-01 to a datetime object
--------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------
factory.py                  24 DEBUG    Date string is: 2019-01-01:2019-02-01
factory.py                  47 DEBUG    Will try to convert string 2019-01-01:2019-02-01 to a datetime object
```
