### PR TITLE
Refactor slack_client_responder

### DIFF
--- a/tests/test_timereport.py
+++ b/tests/test_timereport.py
@@ -129,7 +129,7 @@ def test_slack_client_responder():
     fake_headers = {'Content-Type': 'application/json; charset=utf-8', 'Authorization': 'Bearer fake'}
     when(requests).post(
         url=fake_url, json=fake_data, headers=fake_headers
-    ).thenReturn(mock({'status_code': 200, 'text': 'fake response'}))
+    ).thenReturn(mock({'status_code': 200}))
 
     test_result = slack_client_responder(
         token='fake',
@@ -138,6 +138,23 @@ def test_slack_client_responder():
         attachment='fake',
         url=fake_url,
     )
-    for generator in test_result:
-        assert generator == 'fake response'
-    unstub()
+
+    assert test_result.status_code == 200
+
+
+def test_slack_client_responder_failure():
+    fake_url = 'http://fake2.com'
+    fake_data = {'channel': 'fake', 'text': 'fake from slack.py', 'attachments': 'fake'}
+    fake_headers = {'Content-Type': 'application/json; charset=utf-8', 'Authorization': 'Bearer fake'}
+    when(requests).post(
+        url=fake_url, json=fake_data, headers=fake_headers
+    ).thenReturn(mock({'status_code': 500}))
+
+    test_result = slack_client_responder(
+        token='fake',
+        channel_id='fake',
+        user_id='fake',
+        attachment='fake',
+        url=fake_url,
+    )
+    assert test_result.status_code != 200

--- a/timereport/app.py
+++ b/timereport/app.py
@@ -103,21 +103,19 @@ def index():
         # create attachment with above values for submit button
         attachment = submit_message_menu(user_name, reason, date_start, date_end, hours)
         logger.info(f"Attachment is: {attachment}")
+
         slack_client_response = slack_client_responder(
             token=os.getenv('slack_token'),
             channel_id=channel_id,
             user_id=user_id,
             attachment=attachment
         )
-        if isinstance(slack_client_response, tuple):
-            app.log.debug(f'Failed to return anything: {slack_client_response[1]}')
-        else:
-            app.log.debug(f'response from slack responder is {slack_client_response}')
 
-            for e in slack_client_response:
-                app.log.debug(f'response is {e}')
-                return ''
-
+        if slack_client_response.status_code != 200:
+            app.log.error(
+                f"""Failed to send response to slack. Status code was: {slack_client_response.status_code}.
+                The response from slack was: {slack_client_response.text}"""
+            )
         return ''
 
     if action == "list":
@@ -153,11 +151,11 @@ def index():
             user_id=user_id,
             attachment=attachment
         )
-
-        for event in slack_client_response:
-            app.log.debug(f'response for delete message menu is {event}')
-            return ''
-
+        if slack_client_response.status_code != 200:
+            app.log.error(
+                f"""Failed to send response to slack. Status code was: {slack_client_response.status_code}.
+                The response from slack was: {slack_client_response.text}"""
+            )
         return ''
 
     slack_responder(response_url, "Unsupported action")

--- a/timereport/chalicelib/lib/slack.py
+++ b/timereport/chalicelib/lib/slack.py
@@ -8,15 +8,22 @@ log = logging.getLogger(__name__)
 
 
 def slack_client_responder(token, channel_id, user_id, attachment, url='https://slack.com/api/chat.postMessage'):
+    """
+    Send a response to slack
+
+    :param token: slack token
+    :param channel_id: The slack channel id
+    :param user_id: The user id
+    :param attachment: The slack attachment
+    :param url: The slack URL
+    :return: request respone object
+    """
     headers = {'Content-Type': 'application/json; charset=utf-8', 'Authorization': f'Bearer {token}'}
-    res = requests.post(url=url,
-                        json={'channel': channel_id, 'text': f'{user_id} from slack.py', 'attachments': attachment},
-                        headers=headers
-                        )
-    if res.status_code == 200:
-        yield res.text
-    else:
-        return False, res.status_code
+    return requests.post(
+        url=url,
+        json={'channel': channel_id, 'text': f'{user_id} from slack.py', 'attachments': attachment},
+        headers=headers
+    )
 
 
 def slack_responder(url, msg):


### PR DESCRIPTION
* It will now use `return` instead of `yield`.
* Add test when response isn't 200.
* Update docstring
* Log error message when status code isn't 200 from slack.

fixes #59