### PR TITLE
Send confirmation message as ephemeral

### DIFF
--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -48,7 +48,7 @@ def test_slack_client_responder():
 
 
 def test_slack_client_responder_failure():
-    fake_url = 'http://fake2.com'
+    fake_url = 'http://fake_slack_url.com'
     fake_data = {'channel': 'fake', 'text': 'fake from slack.py', 'attachments': 'fake'}
     fake_headers = {'Content-Type': 'application/json; charset=utf-8', 'Authorization': 'Bearer fake'}
     when(requests).post(

--- a/timereport/chalicelib/lib/slack.py
+++ b/timereport/chalicelib/lib/slack.py
@@ -7,16 +7,17 @@ import json
 log = logging.getLogger(__name__)
 
 
-def slack_client_responder(token, channel_id, user_id, attachment, url='https://slack.com/api/chat.postMessage'):
+def slack_client_responder(token, channel_id, user_id, attachment, url='https://slack.com/api/chat.postEphemeral'):
     """
-    Send a response to slack
+    Sends an ephemeral message to a user in a channel.
+    https://api.slack.com/methods/chat.postEphemeral
 
     :param token: slack token
     :param channel_id: The slack channel id
     :param user_id: The user id
     :param attachment: The slack attachment
     :param url: The slack URL
-    :return: request respone object
+    :return: request response object
     """
     headers = {'Content-Type': 'application/json; charset=utf-8', 'Authorization': f'Bearer {token}'}
     return requests.post(


### PR DESCRIPTION
Instead of sending the message visible to everyone in channel it will
now send it as visible to the user only.

Note that I haven't tested this.

Fixes #49