### PR TITLE
Send feedback for interactive messages to user

### DIFF
--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -33,7 +33,7 @@ def test_slack_client_responder():
     fake_headers = {'Content-Type': 'application/json; charset=utf-8', 'Authorization': 'Bearer fake'}
     when(requests).post(
         url=fake_url, json=fake_data, headers=fake_headers
-    ).thenReturn(mock({'status_code': 200, 'text': {"ok": 'true', "message_ts": "xxxxx"}}))
+    ).thenReturn(mock({'status_code': 200, 'text': '{"ok": "true", "message_ts": "xxxxx"}'}))
 
     test_result = slack_client_responder(
         token='fake',


### PR DESCRIPTION
Instead of sending the feedback from the interactive message action to the channel it
will now send it visible only to the user.

__Note__: This has not been tested.

Fixes #63