### PR TITLE
travis-ci: create separate deployments to dev and prod stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,13 @@ stages:
 jobs:
   include:
     - stage: Test
-      script: pytest -v
+      script:
+      - pytest -v
+      - cd timereport
+      - chalice deploy --stage dev
     - stage: Deploy
       on:
         branch: master
       script: 
       - cd timereport
-      - chalice deploy
+      - chalice deploy --stage prod


### PR DESCRIPTION
This will : 

Dev: 
 - run pytest
 - deploy to dev --stage (here we will have a separate timereport-dev / command

Prod:
 - deploy to prod --stage (this will be the usual / command )

We will have to do the same thing in the backend database